### PR TITLE
Fix FontAwesome chevron icons in listing

### DIFF
--- a/src/features/listing/Listing.js
+++ b/src/features/listing/Listing.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import {
   kformatter,
   previewText,
@@ -50,10 +51,10 @@ export default function Listing(props) {
   return (
     <Paper className="listing">
       <aside>
-        <FontAwesomeIcon icon="chevron-up" size="2x" className="chevron-up" />
+        <FontAwesomeIcon icon={faChevronUp} size="2x" className="chevron-up" />
         <span>{kformatter(score)}</span>
         <FontAwesomeIcon
-          icon="chevron-down"
+          icon={faChevronDown}
           size="2x"
           className="chevron-down"
         />


### PR DESCRIPTION
## Summary
- import the FontAwesome chevron icons used in the listing component
- pass the imported icons to the FontAwesomeIcon elements so the arrows render correctly

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module './App' from 'src/App.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68cd0e3fbc88832da62b694c68022fc9